### PR TITLE
Conjoint AVB

### DIFF
--- a/avb/data_iterator.py
+++ b/avb/data_iterator.py
@@ -98,12 +98,9 @@ class AVBDataIterator(DataIterator):
                 yield data[batch_indices].astype(np.float32)
 
 
-VAEDataIterator = AVBDataIterator
-
-
-class ConjointVAEDataIterator(DataIterator):
+class ConjointAVBDataIterator(DataIterator):
     def __init__(self, data_dim, latent_dim, seed=7):
-        super(ConjointVAEDataIterator, self).__init__(seed=seed, data_dim=data_dim, latent_dim=latent_dim)
+        super(ConjointAVBDataIterator, self).__init__(seed=seed, data_dim=data_dim, latent_dim=latent_dim)
 
     def iter_data_training(self, data, n_batches, **kwargs):
         group_by_target = kwargs.get('group_by_target', True)
@@ -152,3 +149,7 @@ class ConjointVAEDataIterator(DataIterator):
         while True:
             for batch_indices in np.split(np.arange(data_size), n_batches):
                 yield data[batch_indices].astype(np.float32)
+
+
+ConjointVAEDataIterator = ConjointAVBDataIterator
+VAEDataIterator = AVBDataIterator

--- a/avb/models/__init__.py
+++ b/avb/models/__init__.py
@@ -1,4 +1,4 @@
 from .base_vae import BaseVariationalAutoencoder
 from .gaussian_vae import GaussianVariationalAutoencoder, ConjointGaussianVariationalAutoencoder
-from .avb import AdversarialVariationalBayes
+from .avb import AdversarialVariationalBayes, ConjointAdversarialVariationalBayes
 from .freezable import FreezableModel

--- a/avb/models/avb.py
+++ b/avb/models/avb.py
@@ -8,8 +8,8 @@ from tqdm import tqdm
 
 from ..utils.config import load_config
 from .losses import AVBDiscriminatorLossLayer, AVBEncoderDecoderLossLayer
-from .networks import StandardEncoder, MomentEstimationEncoder, StandardDecoder, Discriminator, AdaptivePriorDiscriminator
-from ..data_iterator import AVBDataIterator
+from .networks import *
+from ..data_iterator import AVBDataIterator, ConjointAVBDataIterator
 from ..models.base_vae import BaseVariationalAutoencoder
 from ..models.freezable import FreezableModel
 
@@ -142,6 +142,146 @@ class AdversarialVariationalBayes(BaseVariationalAutoencoder):
         Keyword Args:
             discriminator_repetitions: int, gives the number of iterations for the discriminator network 
                 for each batch training of the encoder-decoder network 
+            checkpoint_best: bool, whether to look at the loss and save the improving model
+
+        Returns:
+            The training history as a dict of lists of the epoch-wise losses.
+        """
+        discriminator_repetitions = kwargs.get('discriminator_repetitions', 1)
+        # NOTE: checkpointing based on the loss doesn't make much sense in this case.
+        # TODO: Maybe fix with some sort of ELBO estimation validation in the future
+        checkpoint_best = kwargs.get('checkpoint_best', False)
+        data_iterator, iters_per_epoch = self.data_iterator.iter(data, batch_size, mode='training', shuffle=True)
+        history = {'encoderdecoder_loss': [], 'discriminator_loss': []}
+        epoch_loss = np.inf
+
+        for ep in tqdm(range(epochs)):
+            epoch_loss_history_encdec = []
+            epoch_loss_history_disc = []
+            for it in range(iters_per_epoch):
+                training_batch = next(data_iterator)
+                loss_autoencoder = self.avb_trainable_encoder_decoder.train_on_batch(training_batch, None)
+                epoch_loss_history_encdec.append(loss_autoencoder)
+                for _ in range(discriminator_repetitions):
+                    loss_discriminator = self.avb_trainable_discriminator.train_on_batch(training_batch, None)
+                    epoch_loss_history_disc.append(loss_discriminator)
+
+            if checkpoint_best:
+                current_epoch_loss = np.mean(epoch_loss_history_encdec) + np.mean(epoch_loss_history_disc)
+                if current_epoch_loss < 0.9 * epoch_loss:
+                    epoch_loss = current_epoch_loss
+                    self.save(os.path.join(config['temp_dir'], 'ep_{}_loss_{}'.format(ep, epoch_loss)))
+            history['encoderdecoder_loss'].append(epoch_loss_history_encdec)
+            history['discriminator_loss'].append(epoch_loss_history_disc)
+
+        return history
+
+
+class ConjointAdversarialVariationalBayes(BaseVariationalAutoencoder):
+    """
+    A conjoint VAE variation using Adversarial Variational Bayes model as per "Adversarial Variational Bayes,
+    Unifying Variational Autoencoders with Generative Adversarial Networks, L. Mescheder et al., arXiv 2017"
+    """
+
+    def __init__(self, data_dims, latent_dims, noise_dim=None,
+                 resume_from=None,
+                 experiment_architecture='synthetic',
+                 use_adaptive_contrast=False,
+                 noise_basis_dim=None,
+                 optimiser_params=None):
+        """
+        Args:
+            data_dims: int, flattened data dimensionality
+            latent_dims: int, flattened latent dimensionality
+            noise_dim: int, flattened noise, dimensionality
+            resume_from: str, directory with h5 and json files with the model weights and architecture
+            experiment_architecture: str, network architecture descriptor
+            use_adaptive_contrast: bool, whether to use an auxiliary distribution with known density,
+                which is closer to q(z|x) and allows for improving the power of the discriminator.
+            noise_basis_dim: int, noise basis dimensionality in case adaptive contrast is used.
+            optimiser_params: dict, optional optimiser parameters
+        """
+        self.data_dim = data_dims
+        self.noise_dim = noise_dim or data_dims
+        self.latent_dim = latent_dims
+
+        self.models_dict = {'avb_trainable_discriminator': None, 'avb_trainable_encoder_decoder': None}
+
+        if use_adaptive_contrast:
+            self.name = "avb_with_ac"
+            self.noise_basis_dim = noise_basis_dim
+            raise NotImplementedError("AC for the conjoint AVB model is not supported yet.")
+        else:
+            self.name = "avb"
+            self.encoder = StandardConjointEncoder(data_dims=data_dims, noise_dim=noise_dim, latent_dims=latent_dims,
+                                                   network_architecture=experiment_architecture)
+            self.discriminator = ConjointDiscriminator(data_dims=data_dims, latent_dims=latent_dims,
+                                                       network_architecture=experiment_architecture)
+        self.decoder = ConjointDecoder(latent_dims=latent_dims, data_dims=data_dims,
+                                       network_architecture=experiment_architecture)
+
+        super(ConjointAdversarialVariationalBayes, self).__init__(data_dim=data_dims, noise_dim=noise_dim,
+                                                                  latent_dim=sum(latent_dims), name_prefix=self.name)
+        if use_adaptive_contrast:
+            raise NotImplementedError("AC for the conjoint AVB model is not supported yet.")
+        else:
+            posterior_approximation = self.encoder(self.data_input, is_learning=True)
+            discriminator_output_prior = self.discriminator(self.data_input, from_posterior=False)
+            discriminator_output_posterior = self.discriminator(self.data_input + [posterior_approximation],
+                                                                from_posterior=True)
+            reconstruction_log_likelihood = self.decoder(self.data_input + [posterior_approximation],
+                                                         is_learning=True)
+
+            discriminator_loss = AVBDiscriminatorLossLayer(name='disc_loss')([discriminator_output_prior,
+                                                                              discriminator_output_posterior],
+                                                                             is_in_logits=True)
+            decoder_loss = AVBEncoderDecoderLossLayer(name='dec_loss')([reconstruction_log_likelihood,
+                                                                        discriminator_output_posterior],
+                                                                       use_adaptive_contrast=False)
+
+        # define the trainable models
+        self.avb_trainable_discriminator = FreezableModel(inputs=self.data_input,
+                                                          outputs=discriminator_loss,
+                                                          name='freezable_discriminator')
+        self.avb_trainable_encoder_decoder = FreezableModel(inputs=self.data_input,
+                                                            outputs=decoder_loss,
+                                                            name='freezable_encoder_decoder')
+
+        if resume_from is not None:
+            self.load(resume_from, custom_layers={'AVBDiscriminatorLossLayer': AVBDiscriminatorLossLayer,
+                                                  'AVBEncoderDecoderLossLayer': AVBEncoderDecoderLossLayer,
+                                                  'FreezableModel': FreezableModel})
+
+        optimiser_params = optimiser_params or {'encdec': {'lr': 1e-4, 'beta_1': 0.5},
+                                                'disc': {'lr': 2e-4, 'beta_1': 0.5}}
+        self.avb_trainable_discriminator.freeze(freezable_layers_prefix=['disc'], deep_freeze=True)
+        self.avb_trainable_encoder_decoder.unfreeze(unfreezable_layers_prefix=['dec', 'enc'], deep_unfreeze=True)
+        optimiser_params_encdec = optimiser_params['encdec']
+        self.avb_trainable_encoder_decoder.compile(optimizer=Adam(**optimiser_params_encdec), loss=None)
+
+        self.avb_trainable_discriminator.unfreeze()
+        self.avb_trainable_encoder_decoder.freeze()
+        optimiser_params_disc = optimiser_params['disc']
+        self.avb_trainable_discriminator.compile(optimizer=Adam(**optimiser_params_disc), loss=None)
+
+        self.models_dict['avb_trainable_encoder_decoder'] = self.avb_trainable_encoder_decoder
+        self.models_dict['avb_trainable_discriminator'] = self.avb_trainable_discriminator
+
+        self.data_iterator = ConjointAVBDataIterator(data_dim=data_dims, latent_dim=latent_dims,
+                                                     seed=config['seed'])
+
+    def fit(self, data, batch_size=32, epochs=1, **kwargs):
+        """
+        Fit the model to the training data.
+
+        Args:
+            data: ndarray, data array of shape (N, data_dim)
+            batch_size: int, the number of samples to be used at one training pass
+            epochs: int, the number of epochs for training (whole size data iterations)
+
+        Keyword Args:
+            discriminator_repetitions: int, gives the number of iterations for the discriminator network
+                for each batch training of the encoder-decoder network
             checkpoint_best: bool, whether to look at the loss and save the improving model
 
         Returns:

--- a/avb/models/networks/__init__.py
+++ b/avb/models/networks/__init__.py
@@ -1,4 +1,4 @@
 from .decoder import StandardDecoder, ConjointDecoder
-from .discriminator import Discriminator, AdaptivePriorDiscriminator
+from .discriminator import Discriminator, AdaptivePriorDiscriminator, ConjointDiscriminator
 from .encoder import StandardEncoder, ReparametrisedGaussianEncoder, \
-    MomentEstimationEncoder, ReparametrisedGaussianConjointEncoder
+    MomentEstimationEncoder, ReparametrisedGaussianConjointEncoder, StandardConjointEncoder

--- a/avb/models/networks/architectures.py
+++ b/avb/models/networks/architectures.py
@@ -345,20 +345,20 @@ def mnist_adaptive_prior_discriminator(data_dim, latent_dim):
     return discriminator_model
 
 
-def mnist_discriminator_simple(data_dim, latent_dim):
-    data_input = Input(shape=(data_dim,), name='disc_internal_data_input')
+def mnist_discriminator_simple(data_dim, latent_dim, name_prefix=''):
+    data_input = Input(shape=(data_dim,), name=name_prefix + 'disc_internal_data_input')
     # center the data around 0 in [-1, 1] as it is in [0, 1].
-    centered_data = Lambda(lambda x: 2 * x - 1, name='disc_centering_data_input')(data_input)
-    discriminator_body_data = repeat_dense(centered_data, n_layers=3, n_units=512, name_prefix='disc_body_data')
+    centered_data = Lambda(lambda x: 2 * x - 1, name=name_prefix + 'disc_centering_data_input')(data_input)
+    discriminator_body_data = repeat_dense(centered_data, n_layers=4, n_units=512, name_prefix=name_prefix + '_data')
 
-    latent_input = Input(shape=(latent_dim,), name='disc_internal_latent_input')
-    discriminator_body_latent = repeat_dense(latent_input, n_layers=4, n_units=512, name_prefix='disc_body_latent')
+    latent_input = Input(shape=(latent_dim,), name=name_prefix + 'disc_internal_latent_input')
+    discriminator_body_latent = repeat_dense(latent_input, n_layers=4, n_units=512, name_prefix=name_prefix + '_latent')
 
-    discriminator_output = Dot(axes=-1, name='disc_dot_sigma_theta')([discriminator_body_data,
-                                                                      discriminator_body_latent])
+    discriminator_output = Dot(axes=-1, name=name_prefix + 'disc_dot_sigma_theta')([discriminator_body_data,
+                                                                                    discriminator_body_latent])
 
     discriminator_model = Model(inputs=[data_input, latent_input], outputs=discriminator_output,
-                                name='disc_internal_model')
+                                name=name_prefix + 'disc_internal_model')
     return discriminator_model
 
 

--- a/avb/models/networks/discriminator.py
+++ b/avb/models/networks/discriminator.py
@@ -2,11 +2,12 @@ from __future__ import absolute_import
 
 import logging
 
-from keras.layers import Lambda
+from keras.layers import Lambda, Concatenate, Add
 from keras.models import Model, Input
 
 from .sampling import sample_adaptive_normal_noise
 from .architectures import get_network_by_name
+from .generic_layer_utils import slice_vector
 from ...utils.config import load_config
 
 config = load_config('global_config.yaml')
@@ -153,6 +154,87 @@ class AdaptivePriorDiscriminator(BaseDiscriminator):
 
         Returns:
             A trainable Discriminator model. 
+        """
+        from_posterior = kwargs.get('from_posterior', False)
+        if not from_posterior:
+            return self.discriminator_from_prior_model(args[0])
+        return self.discriminator_from_posterior_model(args[0])
+
+
+class ConjointDiscriminator(object):
+    """
+    Discriminator taking a concatenated latent space from multiple (conjoint) encoders.
+
+    -------------               -------------
+    | Encoder_1 | ---- ... ---- | Encoder_n |
+    -------------               -------------
+               \                 /
+                -------- --------
+                        V
+              Conjoint latent space
+               \__ __/ ... \__ __/
+                  V           V
+            ----------   ----------
+            | Disc_1 |   | Disc_n |
+            ----------   ----------
+
+    Note:
+        The interaction between an encoder and corresponding discriminator remains the same as in the non-conjoint case
+    """
+    def __init__(self, data_dims, latent_dims, network_architecture='synthetic'):
+        name = "Conjoint Discriminator"
+        logger.info("Initialising {} model with {}-dimensional data "
+                    "and {}-dimensional prior/latent input.".format(name, data_dims, latent_dims))
+
+        self.data_inputs = [Input(shape=(d,), name='disc_data_inp_{}'.format(i)) for i, d in enumerate(data_dims)]
+        self.latent_inputs = Input(shape=(sum(latent_dims),), name='disc_latent_inp')
+
+        shared_latent_factors = Lambda(slice_vector, arguments={'start': -latent_dims[-1], 'stop': None},
+                                       name='dec_slice_shared_lat')(self.latent_inputs)
+        self.prior_sampler = Lambda(sample_adaptive_normal_noise, name='disc_prior_sampler')
+        self.prior_sampler.arguments = {'latent_dim': max(latent_dims[:-1]) + latent_dims[-1], 'seed': config['seed']}
+        noise = self.prior_sampler(self.data_inputs[0])
+
+        from_prior_outputs, from_posterior_outputs = [], []
+        stop_id = 0
+        for i in range(len(data_dims)):
+            start_id = stop_id
+            stop_id += latent_dims[i]
+            disc_body = get_network_by_name['discriminator'][network_architecture](data_dims[i],
+                                                                                   latent_dims[i] + latent_dims[-1],
+                                                                                   name_prefix='disc_{}'.format(i))
+
+            prior_distribution = Lambda(slice_vector, arguments={'start': 0, 'stop': latent_dims[i] + latent_dims[-1]},
+                                        name='disc_slice_noise_{}'.format(i))(noise)
+
+            from_prior_outputs.append(disc_body([self.data_inputs[i], prior_distribution]))
+
+            latent_i = Lambda(slice_vector, arguments={'start': start_id, 'stop': stop_id},
+                              name='disc_slice_{}'.format(i))(self.latent_inputs)
+            latent_i = Concatenate(axis=-1, name='dec_merged_latent_{}'.format(i))([latent_i, shared_latent_factors])
+            from_posterior_outputs.append(disc_body([self.data_inputs[i], latent_i]))
+
+        from_prior_output = Add(name='disc_add_prior_outputs')(from_prior_outputs)
+        self.discriminator_from_prior_model = Model(inputs=self.data_inputs, outputs=from_prior_output,
+                                                    name='discriminator_from_prior')
+
+        from_posterior_output = Add(name='disc_add_post_outputs')(from_posterior_outputs)
+        self.discriminator_from_posterior_model = Model(inputs=self.data_inputs + [self.latent_inputs],
+                                                        outputs=from_posterior_output,
+                                                        name='discriminator_from_posterior')
+
+    def __call__(self, *args, **kwargs):
+        """
+        Make the Discriminator model callable on a list of Inputs (coming from the AVB model)
+
+        Args:
+            *args: a list of Input layers
+
+        Keyword Args:
+            from_posterior: bool, whether the input is data and posterior or data and prior (prior is internal)
+
+        Returns:
+            A trainable Discriminator model.
         """
         from_posterior = kwargs.get('from_posterior', False)
         if not from_posterior:

--- a/avb/models/networks/generic_layer_utils.py
+++ b/avb/models/networks/generic_layer_utils.py
@@ -1,0 +1,8 @@
+
+
+# evt. set the output_shape arg.
+def slice_vector(x, start=0, stop=None):
+    if stop is None:
+        return x[:, start:]
+    else:
+        return x[:, start:stop]

--- a/launcher.py
+++ b/launcher.py
@@ -2,7 +2,7 @@ from numpy import save as save_array
 from os.path import join as path_join
 from numpy import repeat, asarray
 from avb.utils.visualisation import plot_latent_2d, plot_sampled_data, plot_reconstructed_data
-from avb.model_trainer import ConjointVAEModelTrainer
+from avb.model_trainer import ConjointVAEModelTrainer, ConjointAVBModelTrainer
 from avb.utils.datasets import load_npoints, load_mnist
 from avb.utils.logger import logger
 from keras.backend import clear_session
@@ -14,7 +14,7 @@ from keras.backend import clear_session
 # set_session(tf.Session(config=config))
 
 
-def run_synthetic_experiment():
+def run_synthetic_experiment(pretrained_model=None):
     logger.info("Starting a conjoint model experiment on the synthetic dataset.")
     data_dims = (4, 4)
     latent_dims = (2, 2, 2)
@@ -34,7 +34,8 @@ def run_synthetic_experiment():
 
     trainer = ConjointVAEModelTrainer(data_dims=data_dims, latent_dims=latent_dims,
                                       experiment_name='synthetic', architecture='synthetic',
-                                      overwrite=True, optimiser_params={'lr': 0.001})
+                                      overwrite=True, optimiser_params={'lr': 0.001},
+                                      pretrained_dir=pretrained_model)
 
     model_dir = trainer.run_training(data, batch_size=600, epochs=1000)
     trained_model = trainer.get_model()
@@ -67,23 +68,33 @@ def run_synthetic_experiment():
     return model_dir
 
 
-def run_mnist_experiment(pretrained_model=None):
+def run_mnist_experiment(model='avb', pretrained_model=None):
     logger.info("Starting a conjoint model experiment on the MNIST Variations dataset.")
     data_dims = (784, 784)
     latent_dims = (2, 2, 2)
     data_0 = load_mnist(one_hot=False, binarised=False, background=None, rotated=False)
     data_1 = load_mnist(one_hot=False, binarised=False, background='image', rotated=False)
-    train_data = ({'data': data_0['data'][:-1000], 'target': data_0['target'][:-1000]},
-                  {'data': data_1['data'][:-1000], 'target': data_1['target'][:-1000]})
+    train_data = ({'data': data_0['data'][:-1000][:100], 'target': data_0['target'][:-1000][:100]},
+                  {'data': data_1['data'][:-1000][:100], 'target': data_1['target'][:-1000][:100]})
     test_data = ({'data': data_0['data'][-1000:], 'target': data_0['target'][-1000:]},
                  {'data': data_1['data'][-1000:], 'target': data_1['target'][-1000:]})
 
-    trainer = ConjointVAEModelTrainer(data_dims=data_dims, latent_dims=latent_dims,
-                                      experiment_name='mnist_variations', architecture='mnist',
-                                      overwrite=True, optimiser_params={'lr': 0.001, 'beta_1': 0.5},
-                                      pretrained_dir=pretrained_model)
+    if model == 'vae':
+        trainer = ConjointVAEModelTrainer(data_dims=data_dims, latent_dims=latent_dims,
+                                          experiment_name='mnist_variations', architecture='mnist',
+                                          overwrite=True, optimiser_params={'lr': 0.001, 'beta_1': 0.5},
+                                          pretrained_dir=pretrained_model)
+    elif model == 'avb':
+        trainer = ConjointAVBModelTrainer(data_dims=data_dims, latent_dims=latent_dims, noise_dim=16,
+                                          use_adaptive_contrast=False,
+                                          optimiser_params=None,
+                                          pretrained_dir=pretrained_model,
+                                          architecture='mnist',
+                                          experiment_name='mnist_variations')
+    else:
+        raise ValueError("Currently only `avb` and `vae` are supported.")
 
-    model_dir = trainer.run_training(train_data, batch_size=100, epochs=1000, save_interrupted=True)
+    model_dir = trainer.run_training(train_data, batch_size=100, epochs=1000, save_interrupted=False)
     # model_dir = 'output/tmp'
     trained_model = trainer.get_model()
 
@@ -116,4 +127,4 @@ def run_mnist_experiment(pretrained_model=None):
 
 
 if __name__ == '__main__':
-    run_mnist_experiment()#pretrained_model='./output/conjoint_gaussian_vae/mnist_variations/final')
+    run_mnist_experiment(model='avb')#pretrained_model='./output/conjoint_gaussian_vae/mnist_variations/final')


### PR DESCRIPTION
Implements the conjoint version of the AVB. Uses similar structure to the conjoint VAE with split inputs/outputs and concatenated latent space. 
The noise addition is probably insufficient as it is added to the input sample only and not to the intermediate layers (in contrast to the original AVB code). Future improvement is to change this.