### PR TITLE
noise mode implementation only

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -14,7 +14,7 @@ from keras.backend import clear_session
 # set_session(tf.Session(config=config))
 
 
-def run_synthetic_experiment(model='avb', pretrained_model=None):
+def run_synthetic_experiment(model='avb', pretrained_model=None, noise_mode='concat'):
     logger.info("Starting a conjoint model experiment on the synthetic dataset.")
     data_dims = (8, 8)
     latent_dims = (2, 2, 2)
@@ -28,16 +28,17 @@ def run_synthetic_experiment(model='avb', pretrained_model=None):
     elif model == 'avb':
         trainer = ConjointAVBModelTrainer(data_dims=data_dims, latent_dims=latent_dims, noise_dim=data_dims[0],
                                           use_adaptive_contrast=False,
-                                          optimiser_params={'encdec': {'lr': 1e-3, 'beta_1': 0.5},
-                                                            'disc': {'lr': 1e-3, 'beta_1': 0.5}},
+                                          optimiser_params={'encdec': {'lr': 3e-4, 'beta_1': 0.5},
+                                                            'disc': {'lr': 3e-4, 'beta_1': 0.5}},
                                           overwrite=True,
                                           pretrained_dir=pretrained_model,
                                           architecture='synthetic',
-                                          experiment_name='synthetic')
+                                          experiment_name='synthetic',
+                                          noise_mode=noise_mode)
     else:
         raise ValueError("Currently only `avb` and `vae` are supported.")
 
-    model_dir = trainer.run_training(data, batch_size=16, epochs=1000, save_interrupted=True)
+    model_dir = trainer.run_training(data, batch_size=16, epochs=100, save_interrupted=True)
     # model_dir = './output/tmp'
     trained_model = trainer.get_model()
 
@@ -136,5 +137,5 @@ def run_mnist_experiment(model='avb', pretrained_model=None):
 
 
 if __name__ == '__main__':
-    # run_synthetic_experiment(model='avb')
-    run_mnist_experiment(model='avb')
+    run_synthetic_experiment(model='avb', noise_mode='product')
+    # run_mnist_experiment(model='avb')

--- a/playground/model_trainer.py
+++ b/playground/model_trainer.py
@@ -294,7 +294,7 @@ class ConjointAVBModelTrainer(ModelTrainer):
 
     def __init__(self, data_dims, latent_dims, noise_dim, experiment_name, architecture,
                  schedule=None, pretrained_dir=None, overwrite=True, use_adaptive_contrast=False,
-                 noise_basis_dim=None, optimiser_params=None):
+                 noise_basis_dim=None, optimiser_params=None, noise_mode='add'):
         """
         Args:
             data_dims: tuple, all flattened data dimensionalities for each dataset
@@ -308,9 +308,11 @@ class ConjointAVBModelTrainer(ModelTrainer):
             noise_basis_dim: int, the dimensionality of the noise basis vectors if AC is used.
             optimiser_params: dict, parameters for the optimiser
             pretrained_dir: str, directory from which pre-trained models (hdf5 files) can be loaded
+            noise_mode: str, the way the noise will be merged with the input('add', 'concat', 'product')
         """
         conj_avb = ConjointAdversarialVariationalBayes(data_dims=data_dims, latent_dims=latent_dims, noise_dim=noise_dim,
                                                        noise_basis_dim=noise_basis_dim,
+                                                       noise_mode=noise_mode,
                                                        use_adaptive_contrast=use_adaptive_contrast,
                                                        optimiser_params=optimiser_params,
                                                        resume_from=pretrained_dir,

--- a/playground/models/avb.py
+++ b/playground/models/avb.py
@@ -184,6 +184,7 @@ class ConjointAdversarialVariationalBayes(BaseVariationalAutoencoder):
     """
 
     def __init__(self, data_dims, latent_dims, noise_dim=None,
+                 noise_mode='add',
                  resume_from=None,
                  experiment_architecture='synthetic',
                  use_adaptive_contrast=False,
@@ -194,6 +195,7 @@ class ConjointAdversarialVariationalBayes(BaseVariationalAutoencoder):
             data_dims: int, flattened data dimensionality
             latent_dims: int, flattened latent dimensionality
             noise_dim: int, flattened noise, dimensionality
+            noise_mode: str, the way the noise will be merged with the input('add', 'concat', 'product')
             resume_from: str, directory with h5 and json files with the model weights and architecture
             experiment_architecture: str, network architecture descriptor
             use_adaptive_contrast: bool, whether to use an auxiliary distribution with known density,
@@ -214,7 +216,7 @@ class ConjointAdversarialVariationalBayes(BaseVariationalAutoencoder):
         else:
             self.name = "conjoint_avb"
             self.encoder = StandardConjointEncoder(data_dims=data_dims, noise_dim=noise_dim, latent_dims=latent_dims,
-                                                   network_architecture=experiment_architecture)
+                                                   network_architecture=experiment_architecture, noise_mode=noise_mode)
             self.discriminator = ConjointDiscriminator(data_dims=data_dims, latent_dims=latent_dims,
                                                        network_architecture=experiment_architecture)
         self.decoder = ConjointDecoder(latent_dims=latent_dims, data_dims=data_dims,

--- a/playground/models/networks/encoder.py
+++ b/playground/models/networks/encoder.py
@@ -133,17 +133,17 @@ class StandardConjointEncoder(object):
             standard_normal_sampler.arguments = {'seed': config['seed'], 'noise_dim': noise_dim, 'mode': 'add'}
         elif noise_mode == 'concat':
             if network_architecture == 'mnist':
-                assert ((noise_dim % sqrt(data_dims[0]) == 0) & (noise_dim % sqrt(data_dims[1]) == 0)), \
+                assert ((noise_dim % sqrt(data_dims[0]) == 0) and (noise_dim % sqrt(data_dims[1]) == 0)), \
                 'Expected to receive a noise_dim that can form a rectangle with the given inputs_dims. Received {} as noise' \
                 'and {} and {} for the data dimension.'.format(noise_dim, data_dims[0], data_dims[1])
             standard_normal_sampler.arguments = {'seed': config['seed'], 'noise_dim': noise_dim, 'mode': 'concatenate'}
         elif noise_mode == 'product':
-            assert data_dims[0] == noise_dim & data_dims[1] == noise_dim, \
+            assert data_dims[0] == noise_dim and data_dims[1] == noise_dim, \
             'Expected to receive a noise_dim that is equal to the given inputs_dims. Received {} as noise' \
             'and {} and {} for the data dimension.'.format(noise_dim, data_dims[0], data_dims[1])
             standard_normal_sampler.arguments = {'seed': config['seed'], 'noise_dim': noise_dim, 'mode': 'product'}
         else:
-            raise NotImplementedError("Only the noise modes 'add', 'concat' and 'product' are available.")
+            raise ValueError("Only the noise modes 'add', 'concat' and 'product' are available.")
 
         for i, inp in enumerate(inputs):
             noise_input = standard_normal_sampler(inp)

--- a/playground/models/networks/encoder.py
+++ b/playground/models/networks/encoder.py
@@ -5,6 +5,7 @@ import logging
 import keras.backend as ker
 
 from numpy import pi as pi_const
+from numpy import sqrt
 from keras.layers import Lambda, Multiply, Add, Dense, Concatenate
 from keras.models import Input
 from keras.models import Model
@@ -107,7 +108,7 @@ class StandardConjointEncoder(object):
 
         """
 
-    def __init__(self, data_dims, noise_dim, latent_dims, network_architecture='synthetic'):
+    def __init__(self, data_dims, noise_dim, latent_dims, network_architecture='synthetic', noise_mode='add'):
         """
         Args:
             data_dims: tuple, flattened data dimension for each dataset
@@ -115,6 +116,7 @@ class StandardConjointEncoder(object):
             latent_dims: tuple, flattened latent dimensions for each private latent space and the dimension
                 of the shared space.
             network_architecture: str, the codename of the encoder network architecture (will be the same for all)
+            noise_mode: str, the way the noise will be merged with the input('add', 'concat', 'product')
         """
         assert len(latent_dims) == len(data_dims) + 1, \
             "Expected too receive {} private latent spaces and one shared for {} data inputs " \
@@ -127,10 +129,22 @@ class StandardConjointEncoder(object):
         latent_space, features = [], []
         inputs = [Input(shape=(dim,), name="enc_data_input_{}".format(i)) for i, dim in enumerate(data_dims)]
         standard_normal_sampler = Lambda(sample_standard_normal_noise, name='enc_normal_sampler')
-        if network_architecture == 'synthetic':
-            standard_normal_sampler.arguments = {'seed': config['seed'], 'noise_dim': noise_dim, 'mode': 'concatenate'}
-        else:
+        if noise_mode == 'add':
             standard_normal_sampler.arguments = {'seed': config['seed'], 'noise_dim': noise_dim, 'mode': 'add'}
+        elif noise_mode == 'concat':
+            if network_architecture == 'mnist':
+                assert ((noise_dim % sqrt(data_dims[0]) == 0) & (noise_dim % sqrt(data_dims[1]) == 0)), \
+                'Expected to receive a noise_dim that can form a rectangle with the given inputs_dims. Received {} as noise' \
+                'and {} and {} for the data dimension.'.format(noise_dim, data_dims[0], data_dims[1])
+            standard_normal_sampler.arguments = {'seed': config['seed'], 'noise_dim': noise_dim, 'mode': 'concatenate'}
+        elif noise_mode == 'product':
+            assert data_dims[0] == noise_dim & data_dims[1] == noise_dim, \
+            'Expected to receive a noise_dim that is equal to the given inputs_dims. Received {} as noise' \
+            'and {} and {} for the data dimension.'.format(noise_dim, data_dims[0], data_dims[1])
+            standard_normal_sampler.arguments = {'seed': config['seed'], 'noise_dim': noise_dim, 'mode': 'product'}
+        else:
+            raise NotImplementedError("Only the noise modes 'add', 'concat' and 'product' are available.")
+
         for i, inp in enumerate(inputs):
             noise_input = standard_normal_sampler(inp)
             feature = get_network_by_name['conjoint_encoder'][network_architecture](noise_input,

--- a/playground/models/networks/sampling.py
+++ b/playground/models/networks/sampling.py
@@ -1,4 +1,20 @@
-from keras.layers import Dense, Concatenate, Add
+from keras.layers import Dense, Concatenate, Add, Lambda, Reshape
+from keras import backend as K
+from numpy import newaxis
+
+
+def outer_product(inputs):
+    """
+    inputs: list of two tensors (of equal dimensions,
+        for which you need to compute the outer product
+    """
+    x, y = inputs
+    feature_size = x._shape_as_list()[1] ** 2
+    outer_Product = x[:,:, newaxis] * y[:,newaxis,:]
+    outer_Product = K.reshape(outer_Product, (-1, feature_size))
+    #outerProduct = K.reshape(outerProduct, (batchSize, -1))
+    # returns a flattened batch-wise set of tensors
+    return outer_Product
 
 
 def sample_standard_normal_noise(inputs, **kwargs):
@@ -23,6 +39,11 @@ def sample_standard_normal_noise(inputs, **kwargs):
         resized_noise = Dense(data_dim, activation=None, name='enc_resized_noise_sampler')(samples_isotropic)
         added_noise_data = Add(name='enc_adding_noise_data')([inputs, resized_noise])
         return added_noise_data
+    elif op_mode == 'product':
+        outputshape = noise_dim**2
+        bilinearProduct = Lambda(outer_product, output_shape=(noise_dim ** 2, ))([inputs, samples_isotropic])
+        # bilinearProduct = Reshape((outputshape),bilinearProduct)
+        return bilinearProduct
     return samples_isotropic
 
 

--- a/playground/models/networks/sampling.py
+++ b/playground/models/networks/sampling.py
@@ -9,10 +9,9 @@ def outer_product(inputs):
         for which you need to compute the outer product
     """
     x, y = inputs
-    feature_size = x._shape_as_list()[1] ** 2
-    outer_Product = x[:,:, newaxis] * y[:,newaxis,:]
+    feature_size = K.shape(x)[1] ** 2
+    outer_Product = x[:, :, newaxis] * y[:, newaxis, :]
     outer_Product = K.reshape(outer_Product, (-1, feature_size))
-    #outerProduct = K.reshape(outerProduct, (batchSize, -1))
     # returns a flattened batch-wise set of tensors
     return outer_Product
 

--- a/playground/models/networks/sampling.py
+++ b/playground/models/networks/sampling.py
@@ -39,10 +39,8 @@ def sample_standard_normal_noise(inputs, **kwargs):
         added_noise_data = Add(name='enc_adding_noise_data')([inputs, resized_noise])
         return added_noise_data
     elif op_mode == 'product':
-        outputshape = noise_dim**2
-        bilinearProduct = Lambda(outer_product, output_shape=(noise_dim ** 2, ))([inputs, samples_isotropic])
-        # bilinearProduct = Reshape((outputshape),bilinearProduct)
-        return bilinearProduct
+        product_noise = Lambda(outer_product, output_shape=(noise_dim ** 2, ))([inputs, samples_isotropic])
+        return product_noise
     return samples_isotropic
 
 


### PR DESCRIPTION
Implementation of noise mode. 'add', 'concat' and 'product' are available. 
Add - adds the noise vector to the input. Standard because it works good on MNIST.
Concat - concatenates a noise vector of a given size to the input. (-works quite good on mnist and way better on synthetic than add)
Product - performs an outer product from the input and the noise vector of the same size. (works very good on the synthetic dataset but gets very big for the mnist dataset.)