### PR TITLE
CostumMNIST augment()

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -94,22 +94,22 @@ def run_mnist_experiment(model='avb', pretrained_model=None, two_backgrounds_per
         experiment_name = 'mnist_variation_two_backgrounds_per_encoder'
         if small_set:
             local_path_0 = 'data/MNIST_Custom_Variations/strippy_horizontal_and_vertical_small.npz'
-            local_path_1 = 'data/MNIST_Custom_Variations/trippy_and_mandelbrot_small.npz'
+            local_path_1 = 'data/MNIST_Custom_Variations/trippy_and_black_small.npz'
         else:
             local_path_0 = 'data/MNIST_Custom_Variations/strippy_horizontal_and_vertical.npz'
-            local_path_1 = 'data/MNIST_Custom_Variations/trippy_and_mandelbrot.npz'
+            local_path_1 = 'data/MNIST_Custom_Variations/trippy_and_black.npz'
         cmnist = None
         if not isfile(local_path_0):
-            cmnist = CustomMNIST()
+            cmnist = CustomMNIST(small_set)
             new_data = cmnist.augment([0, 1, 0, 0], orientation='vertical_or_horizontal')
             save_as = 'strippy_horizontal_and_vertical'
             if small_set: save_as += '_small'
             cmnist.save_dataset(new_data, save_as)
         data_0 = load_mnist(local_path_0, one_hot=False, binarised=False, background='custom')
         if not isfile(local_path_1):
-            if not cmnist: cmnist = CustomMNIST()
-            new_data = cmnist.augment([0.5, 0, 0.5, 0])
-            save_as = 'trippy_and_mandelbrot'
+            cmnist = CustomMNIST(small_set)
+            new_data = cmnist.augment([0.5, 0, 0.5, 0], no_mandelbrot=True)
+            save_as = 'trippy_and_black'
             if small_set: save_as += '_small'
             cmnist.save_dataset(new_data, save_as)
         data_1 = load_mnist(local_path_1, one_hot=False, binarised=False, background='custom')

--- a/launcher.py
+++ b/launcher.py
@@ -137,7 +137,7 @@ def run_mnist_experiment(model='avb', pretrained_model=None, two_backgrounds_per
     else:
         raise ValueError("Currently only `avb` and `vae` are supported.")
 
-    model_dir = trainer.run_training(train_data, batch_size=10, epochs=1,
+    model_dir = trainer.run_training(train_data, batch_size=100, epochs=1000,
                                      save_interrupted=True,
                                      validation_data=test_data,
                                      validation_frequency=20,
@@ -187,6 +187,4 @@ def run_mnist_experiment(model='avb', pretrained_model=None, two_backgrounds_per
 
 
 if __name__ == '__main__':
-    # Two backgrounds per encoder (strippy horizontal/vertical and trippy/mandelbrot)
-    # Datasets (N=50k) are created at 'data/MNIST_Custom_Variations' if they don't exist (may take a while)
     run_mnist_experiment(model='vae', two_backgrounds_per_encoder=True, color_tags=True, small_set=True)

--- a/launcher.py
+++ b/launcher.py
@@ -1,11 +1,13 @@
 from numpy import save as save_array
-from os.path import join as path_join
-from numpy import repeat
+from os.path import join as path_join, isfile
+from numpy import repeat, zeros_like, unique, int8
 from playground.utils.visualisation import plot_latent_2d, plot_sampled_data, plot_reconstructed_data
 from playground.model_trainer import ConjointVAEModelTrainer, ConjointAVBModelTrainer
+from playground.utils.data_factory import CustomMNIST
 from playground.utils.datasets import load_conjoint_synthetic, load_mnist
 from playground.utils.logger import logger
 from keras.backend import clear_session
+
 
 # import tensorflow as tf
 # from keras.backend.tensorflow_backend import set_session
@@ -73,24 +75,53 @@ def run_synthetic_experiment(model='avb', pretrained_model=None, noise_mode='pro
     return model_dir
 
 
-def run_mnist_experiment(model='avb', pretrained_model=None):
+def run_mnist_experiment(model='avb', pretrained_model=None, two_backgrounds_per_encoder=True, color_tags=True,
+                         small_set=False):
     logger.info("Starting a conjoint model experiment on the MNIST Variations dataset.")
     data_dims = (784, 784)
     latent_dims = (2, 2, 2)
-    # data_0 = load_mnist(one_hot=False, binarised=False, background=None, rotated=False)
-    # data_1 = load_mnist(one_hot=False, binarised=False, background='image', rotated=False)
-    data_0 = load_mnist(local_data_path='data/MNIST_Custom_Variations/strippy_horizontal.npz',
-                        one_hot=False, binarised=False, background='custom')
-    data_1 = load_mnist(local_data_path='data/MNIST_Custom_Variations/strippy_checker.npz',
-                        one_hot=False, binarised=False, background='custom')
-    train_data = ({'data': data_0['data'][:-100], 'target': data_0['target'][:-100], 'tag': data_0['tag'][:-100]},
-                  {'data': data_1['data'][:-100], 'target': data_1['target'][:-100], 'tag': data_1['tag'][:-100]})
-    test_data = ({'data': data_0['data'][-100:], 'target': data_0['target'][-100:], 'tag': data_0['tag'][-100:]},
-                 {'data': data_1['data'][-100:], 'target': data_1['target'][-100:], 'tag': data_1['tag'][-100:]})
+    test_size = 100
+    if not two_backgrounds_per_encoder:
+        experiment_name = 'mnist_variation'
+        # data_0 = load_mnist(one_hot=False, binarised=False, background=None, rotated=False)
+        # data_1 = load_mnist(one_hot=False, binarised=False, background='image', rotated=False)
+        data_0 = load_mnist(local_data_path='data/MNIST_Custom_Variations/strippy_horizontal.npz',
+                            one_hot=False, binarised=False, background='custom')
+        data_1 = load_mnist(local_data_path='data/MNIST_Custom_Variations/strippy_checker.npz',
+                            one_hot=False, binarised=False, background='custom')
+    elif two_backgrounds_per_encoder:
+        # data sets are generated if not found
+        experiment_name = 'mnist_variation_two_backgrounds_per_encoder'
+        if small_set:
+            local_path_0 = 'data/MNIST_Custom_Variations/strippy_horizontal_and_vertical_small.npz'
+            local_path_1 = 'data/MNIST_Custom_Variations/trippy_and_mandelbrot_small.npz'
+        else:
+            local_path_0 = 'data/MNIST_Custom_Variations/strippy_horizontal_and_vertical.npz'
+            local_path_1 = 'data/MNIST_Custom_Variations/trippy_and_mandelbrot.npz'
+        cmnist = None
+        if not isfile(local_path_0):
+            cmnist = CustomMNIST()
+            new_data = cmnist.augment([0, 1, 0, 0], orientation='vertical_or_horizontal')
+            save_as = 'strippy_horizontal_and_vertical'
+            if small_set: save_as += '_small'
+            cmnist.save_dataset(new_data, save_as)
+        data_0 = load_mnist(local_path_0, one_hot=False, binarised=False, background='custom')
+        if not isfile(local_path_1):
+            if not cmnist: cmnist = CustomMNIST()
+            new_data = cmnist.augment([0.5, 0, 0.5, 0])
+            save_as = 'trippy_and_mandelbrot'
+            if small_set: save_as += '_small'
+            cmnist.save_dataset(new_data, save_as)
+        data_1 = load_mnist(local_path_1, one_hot=False, binarised=False, background='custom')
+
+    train_data = ({'data': data_0['data'][:-test_size], 'target': data_0['target'][:-test_size]},
+                  {'data': data_1['data'][:-test_size], 'target': data_1['target'][:-test_size]})
+    test_data = ({'data': data_0['data'][-test_size:], 'target': data_0['target'][-test_size:]},
+                 {'data': data_1['data'][-test_size:], 'target': data_1['target'][-test_size:]})
 
     if model == 'vae':
         trainer = ConjointVAEModelTrainer(data_dims=data_dims, latent_dims=latent_dims,
-                                          experiment_name='mnist_variations', architecture='mnist',
+                                          experiment_name=experiment_name, architecture='mnist',
                                           overwrite=True, save_best=True,
                                           optimiser_params={'lr': 0.0007, 'beta_1': 0.5},
                                           pretrained_dir=pretrained_model)
@@ -102,11 +133,11 @@ def run_mnist_experiment(model='avb', pretrained_model=None):
                                           overwrite=True, save_best=True,
                                           pretrained_dir=pretrained_model,
                                           architecture='mnist',
-                                          experiment_name='mnist_variations')
+                                          experiment_name=experiment_name)
     else:
         raise ValueError("Currently only `avb` and `vae` are supported.")
 
-    model_dir = trainer.run_training(train_data, batch_size=100, epochs=1000,
+    model_dir = trainer.run_training(train_data, batch_size=10, epochs=1,
                                      save_interrupted=True,
                                      validation_data=test_data,
                                      validation_frequency=20,
@@ -120,12 +151,25 @@ def run_mnist_experiment(model='avb', pretrained_model=None):
     save_array(path_join(model_dir, 'latent_samples.npy'), latent_vars)
     plot_latent_2d(latent_vars[:, -2:], repeat(train_data[0]['target'], sampling_size),
                    fig_dirpath=model_dir, fig_name='shared.png')
+
     stop_id = 0
+    data = (data_0, data_1)
+
     for i, lat_id in enumerate(latent_dims[:-1]):
         start_id = stop_id
         stop_id += lat_id
-        plot_latent_2d(latent_vars[:, start_id:stop_id], repeat(train_data[0]['tag'], sampling_size),
-                       fig_dirpath=model_dir, fig_name='private_{}'.format(i))
+        if color_tags:
+            tags = data[i]['tag'][:-test_size]
+            tags_num = zeros_like(train_data[0]['target'], dtype=int8)
+            tag_dict = dict(enumerate(unique(tags)))
+            assert len(tags_num) == len(tags)
+            for k, v in tag_dict.items():
+                tags_num[tags == v] = k
+            plot_latent_2d(latent_vars[:, start_id:stop_id], repeat(tags_num, sampling_size),
+                           fig_dirpath=model_dir, fig_name='private_{}'.format(i))
+        else:
+            plot_latent_2d(latent_vars[:, start_id:stop_id], repeat(train_data[i]['tag'], sampling_size),
+                           fig_dirpath=model_dir, fig_name='private_{}'.format(i))
 
     reconstructions = trained_model.reconstruct(test_data, batch_size=100, sampling_size=1)
     save_array(path_join(model_dir, 'reconstructed_samples.npy'), reconstructions)
@@ -143,5 +187,6 @@ def run_mnist_experiment(model='avb', pretrained_model=None):
 
 
 if __name__ == '__main__':
-    run_synthetic_experiment(model='avb', noise_mode='product')
-    # run_mnist_experiment(model='avb')
+    # Two backgrounds per encoder (strippy horizontal/vertical and trippy/mandelbrot)
+    # Datasets (N=50k) are created at 'data/MNIST_Custom_Variations' if they don't exist (may take a while)
+    run_mnist_experiment(model='vae', two_backgrounds_per_encoder=True, color_tags=True, small_set=True)

--- a/playground/utils/data_factory.py
+++ b/playground/utils/data_factory.py
@@ -115,8 +115,8 @@ class CustomMNIST(object):
     Factory for customized MNIST digits. Background will have different structure/style.
     """
 
-    def __init__(self):
-        self.data = load_mnist(one_hot=False, binarised=False, rotated=False, background=None, large_set=True)
+    def __init__(self, large_set=True):
+        self.data = load_mnist(one_hot=False, binarised=False, rotated=False, background=None, large_set=large_set)
         self.unique_labels = np.arange(10)
         # group the targets of each dataset by label
         sorted_indices = np.argsort(self.data['target'])

--- a/playground/utils/data_factory.py
+++ b/playground/utils/data_factory.py
@@ -43,6 +43,8 @@ class PatternFactory(object):
     def render_strippy(shape, orientation='horizontal', width=1, height=1, as_gray=False):
         if not as_gray:
             raise NotImplementedError
+        if orientation == 'vertical_or_horizontal':
+            orientation = np.random.choice(['horizontal', 'vertical'])
         if orientation == 'random':
             orientation = np.random.choice(['horizontal', 'vertical', 'checker'])
         if orientation == 'horizontal':
@@ -179,7 +181,7 @@ class CustomMNIST(object):
 
         return augmented_data
 
-    def augment(self, style_distribution=None):
+    def augment(self, style_distribution=None,**kwargs):
         """
         Generate backgrounds for MNIST images, without changing their order
         
@@ -196,7 +198,7 @@ class CustomMNIST(object):
         s_ids = np.random.choice(self.styles.size, size=data_size, replace=True, p=style_distribution)
         for id in range(data_size):
             s_id = s_ids[id]
-            new_sample_background = self._generate_style(style=s_id)
+            new_sample_background = self._generate_style(style=s_id,**kwargs)
             newly_composed_digit = self._compose_new(new_sample_background['image'], self.data['data'][id])
             augmented_data['data'].append(newly_composed_digit)
             augmented_data['target'].append(id)

--- a/playground/utils/data_factory.py
+++ b/playground/utils/data_factory.py
@@ -180,7 +180,19 @@ class CustomMNIST(object):
         return augmented_data
 
     def augment(self, style_distribution=None, **kwargs):
-        raise NotImplementedError
+        augmented_data = {'data': [], 'target': [], 'tag': []}
+        style_distribution = self._get_style_distro(style_distribution)
+        data_size = self.data['target'].shape[0]
+        s_ids = np.random.choice(self.styles.size, size=data_size, replace=True, p=style_distribution)
+        for id in range(data_size):
+            s_id = s_ids[id]
+            new_sample_background = self._generate_style(style=s_id, **kwargs)
+            newly_composed_digit = self._compose_new(new_sample_background['image'], self.data['data'][id])
+            augmented_data['data'].append(newly_composed_digit)
+            augmented_data['target'].append(id)
+            augmented_data['tag'].append(new_sample_background['tag'])
+
+        return augmented_data
 
     # TODO: style_distribiution = None does not work at the moment. Style 3 not implemented
     def _get_style_distro(self, style_distribution):

--- a/playground/utils/data_factory.py
+++ b/playground/utils/data_factory.py
@@ -164,12 +164,9 @@ class CustomMNIST(object):
         """
 
         augmented_data = {'data': [], 'target': [], 'tag': []}
-        if style_distribution is None:
-            style_distribution = np.ones(self.styles.size) / self.styles.size
         if label_distribution is None:
             label_distribution = np.ones(self.unique_labels.size) / self.unique_labels.size
-        if isinstance(style_distribution, dict):
-            style_distribution = [style_distribution[s] if s in style_distribution.keys() else 0 for s in self.styles]
+        style_distribution = self._get_style_distro(style_distribution)
         s_ids = np.random.choice(self.styles.size, size=n_samples, replace=True, p=style_distribution)
         l_ids = np.random.choice(self.unique_labels.size, size=n_samples, replace=True, p=label_distribution)
         for s_id, l_id in zip(s_ids, l_ids):
@@ -181,6 +178,17 @@ class CustomMNIST(object):
             augmented_data['tag'].append(new_sample_background['tag'])
 
         return augmented_data
+
+    def augment(self, style_distribution=None, **kwargs):
+        raise NotImplementedError
+
+    # TODO: style_distribiution = None does not work at the moment. Style 3 not implemented
+    def _get_style_distro(self, style_distribution):
+        if style_distribution is None:
+            style_distribution = np.ones(self.styles.size) / self.styles.size
+        if isinstance(style_distribution, dict):
+            style_distribution = [style_distribution[s] if s in style_distribution.keys() else 0 for s in self.styles]
+        return style_distribution
 
     @staticmethod
     def _compose_new(new_background, old_sample):

--- a/playground/utils/data_factory.py
+++ b/playground/utils/data_factory.py
@@ -117,7 +117,7 @@ class CustomMNIST(object):
     Factory for customized MNIST digits. Background will have different structure/style.
     """
 
-    def __init__(self, smallset=True):
+    def __init__(self, smallset=False):
         self.data = load_mnist(one_hot=False, binarised=False, rotated=False, background=None, large_set=(not smallset))
         self.unique_labels = np.arange(10)
         # group the targets of each dataset by label

--- a/playground/utils/data_factory.py
+++ b/playground/utils/data_factory.py
@@ -179,14 +179,24 @@ class CustomMNIST(object):
 
         return augmented_data
 
-    def augment(self, style_distribution=None, **kwargs):
+    def augment(self, style_distribution=None):
+        """
+        Generate backgrounds for MNIST images, without changing their order
+        
+        Args:
+            style_distribution: list, array of percentage generations for each style (uniform if None)
+
+        Returns:
+            A tuple of a dict with `data`, `target` and `style` keys and a verbal descriptions of the style encoding.
+        """
+
         augmented_data = {'data': [], 'target': [], 'tag': []}
         style_distribution = self._get_style_distro(style_distribution)
         data_size = self.data['target'].shape[0]
         s_ids = np.random.choice(self.styles.size, size=data_size, replace=True, p=style_distribution)
         for id in range(data_size):
             s_id = s_ids[id]
-            new_sample_background = self._generate_style(style=s_id, **kwargs)
+            new_sample_background = self._generate_style(style=s_id)
             newly_composed_digit = self._compose_new(new_sample_background['image'], self.data['data'][id])
             augmented_data['data'].append(newly_composed_digit)
             augmented_data['target'].append(id)
@@ -213,7 +223,7 @@ class CustomMNIST(object):
 
     @staticmethod
     def save_dataset(new_data, tag):
-        assert isinstance(new_data, dict), "Provida a dict data containing at least the keys `data` and `target`."
+        assert isinstance(new_data, dict), "Provide a dict data containing at least the keys `data` and `target`."
         new_data_path = os.path.join(DATA_DIR, 'MNIST_Custom_Variations')
         if not os.path.exists(new_data_path):
             os.makedirs(new_data_path)


### PR DESCRIPTION
Changes to data_factory:

- Add augment(), put background behind MNIST without changing order
- Augment has option to not render mandelbrot, but leave it black
- Add option for randomly choosing between horizontal and vertical strippy
- Option for small dataset in constructor